### PR TITLE
fix: stream message browser fails to load (#1)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -110,7 +110,7 @@ func main() {
 		protected.DELETE("/streams/:name", validateName, streamsH.Delete)
 		protected.POST("/streams/:name/purge", validateName, streamsH.Purge)
 		protected.POST("/streams/:name/seal", validateName, streamsH.Seal)
-		protected.GET("/streams/:name/messages", validateName, streamsH.GetMessage)
+		protected.GET("/streams/:name/messages", validateName, streamsH.GetMessages)
 
 		// Consumers
 		protected.GET("/streams/:name/consumers", validateName, consumersH.List)

--- a/backend/internal/handler/streams.go
+++ b/backend/internal/handler/streams.go
@@ -2,8 +2,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -193,73 +191,6 @@ func (h *StreamsHandler) Purge(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"purged": name, "subject": req.Subject})
-}
-
-func (h *StreamsHandler) GetMessage(c *gin.Context) {
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
-	defer cancel()
-
-	name := c.Param("name")
-	stream, err := h.nc.JS().Stream(ctx, name)
-	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-		return
-	}
-
-	// Get last N messages or by sequence
-	lastN := 10
-	if v := c.Query("last"); v != "" {
-		fmt.Sscanf(v, "%d", &lastN)
-		if lastN > 100 {
-			lastN = 100
-		}
-	}
-
-	info, err := stream.Info(ctx)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	var messages []map[string]any
-	if info.State.Msgs == 0 {
-		c.JSON(http.StatusOK, []map[string]any{})
-		return
-	}
-
-	// Calculate start sequence
-	startSeq := info.State.LastSeq - uint64(lastN) + 1
-	if startSeq < info.State.FirstSeq {
-		startSeq = info.State.FirstSeq
-	}
-
-	for seq := startSeq; seq <= info.State.LastSeq; seq++ {
-		msg, err := stream.GetMsg(ctx, seq)
-		if err != nil {
-			continue
-		}
-		var data any
-		if err := json.Unmarshal(msg.Data, &data); err != nil {
-			data = string(msg.Data)
-		}
-		headers := make(map[string]string)
-		for k, v := range msg.Header {
-			if len(v) > 0 {
-				headers[k] = v[0]
-			}
-		}
-		messages = append(messages, map[string]any{
-			"sequence":  msg.Sequence,
-			"subject":   msg.Subject,
-			"data":      data,
-			"headers":   headers,
-			"timestamp": msg.Time,
-		})
-	}
-	if messages == nil {
-		messages = []map[string]any{}
-	}
-	c.JSON(http.StatusOK, messages)
 }
 
 func (h *StreamsHandler) Delete(c *gin.Context) {

--- a/backend/internal/handler/streams_messages.go
+++ b/backend/internal/handler/streams_messages.go
@@ -77,8 +77,6 @@ func (h *StreamsHandler) GetMessages(c *gin.Context) {
 		if last > maxMessageLimit {
 			last = maxMessageLimit
 		}
-		consumerCfg.DeliverPolicy = jetstream.DeliverLastPerSubjectPolicy
-		// For "last N" we use DeliverAll and calculate start seq
 		info, err := stream.Info(ctx)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -88,12 +86,8 @@ func (h *StreamsHandler) GetMessages(c *gin.Context) {
 			c.JSON(http.StatusOK, []map[string]any{})
 			return
 		}
-		startSeq := info.State.LastSeq - uint64(last) + 1
-		if startSeq < info.State.FirstSeq {
-			startSeq = info.State.FirstSeq
-		}
 		consumerCfg.DeliverPolicy = jetstream.DeliverByStartSequencePolicy
-		consumerCfg.OptStartSeq = startSeq
+		consumerCfg.OptStartSeq = lastNStartSeq(info.State.FirstSeq, info.State.LastSeq, uint64(last))
 		limit = last
 
 	default:
@@ -153,6 +147,20 @@ func (h *StreamsHandler) GetMessages(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, messages)
+}
+
+// lastNStartSeq returns the stream sequence to start delivery from in order to
+// fetch the last `last` messages, clamped to [firstSeq, lastSeq] and guarded
+// against uint64 underflow when the stream has fewer messages than requested.
+func lastNStartSeq(firstSeq, lastSeq, last uint64) uint64 {
+	if last == 0 || last >= lastSeq {
+		return firstSeq
+	}
+	start := lastSeq - last + 1
+	if start < firstSeq {
+		return firstSeq
+	}
+	return start
 }
 
 func parseIntQuery(c *gin.Context, key string, defaultVal int) int {

--- a/backend/internal/handler/streams_messages_test.go
+++ b/backend/internal/handler/streams_messages_test.go
@@ -1,0 +1,30 @@
+package handler
+
+import "testing"
+
+func TestLastNStartSeq(t *testing.T) {
+	cases := []struct {
+		name     string
+		first    uint64
+		last     uint64
+		n        uint64
+		expected uint64
+	}{
+		{"middle of stream", 1, 100, 10, 91},
+		{"exact match returns first", 1, 10, 10, 1},
+		{"n greater than stream size returns first (no underflow)", 1, 5, 50, 1},
+		{"n=0 returns first", 1, 100, 0, 1},
+		{"single message", 1, 1, 1, 1},
+		{"firstSeq > 1 (after purge)", 50, 100, 10, 91},
+		{"n > range after purge clamps to firstSeq", 50, 100, 200, 50},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := lastNStartSeq(c.first, c.last, c.n)
+			if got != c.expected {
+				t.Fatalf("lastNStartSeq(%d, %d, %d) = %d, want %d", c.first, c.last, c.n, got, c.expected)
+			}
+		})
+	}
+}

--- a/frontend/src/components/streams/MessageBrowser.tsx
+++ b/frontend/src/components/streams/MessageBrowser.tsx
@@ -33,6 +33,7 @@ export function MessageBrowser({ streamName, onClose }: MessageBrowserProps) {
   const [subjectFilter, setSubjectFilter] = useState('');
   const [startTime, setStartTime] = useState('');
   const [expandedSeqs, setExpandedSeqs] = useState<Set<number>>(new Set());
+  const [hasFetched, setHasFetched] = useState(false);
 
   const fetchMessages = useCallback(async () => {
     if (!streamName) return;
@@ -52,6 +53,7 @@ export function MessageBrowser({ streamName, onClose }: MessageBrowserProps) {
       setMessages([]);
     } finally {
       setLoading(false);
+      setHasFetched(true);
     }
   }, [streamName, filterMode, limit, lastN, sequence, subjectFilter, startTime]);
 
@@ -150,7 +152,7 @@ export function MessageBrowser({ streamName, onClose }: MessageBrowserProps) {
             </div>
           ) : messages.length === 0 ? (
             <div className="text-center py-12 text-muted-foreground">
-              {messages.length === 0 ? 'Click "Fetch Messages" to load messages' : 'No messages found'}
+              {hasFetched ? 'No messages found' : 'Click "Fetch Messages" to load messages'}
             </div>
           ) : (
             <Table>

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -711,6 +711,7 @@ function SidebarMenuSubButton({
 }
 
 export {
+  // eslint-disable-next-line react-refresh/only-export-components
   useSidebar,
   Sidebar,
   SidebarContent,


### PR DESCRIPTION
## Summary

- Route `/streams/:name/messages` was bound to the legacy `GetMessage` handler that ignored the new filter parameters (`seq`, `subject`, `start_time`, `limit`) sent by the frontend `replayStreamMessages`.
- Both the legacy and the `GetMessages` handlers had a `uint64` underflow in the "last N" calculation: when a stream had fewer messages than requested, `LastSeq - N + 1` wrapped around to a huge sequence and the consumer was created starting past the end of the stream, returning zero messages — which is exactly what users saw when they clicked **Fetch Messages**.
- Extracted the start-sequence calculation into a pure `lastNStartSeq` helper that clamps to `FirstSeq` instead of underflowing, with table-driven tests covering the edge cases (`n > LastSeq`, `n == LastSeq`, post-purge `FirstSeq > 1`, etc.).
- Removed the now-unused legacy `GetMessage` handler.
- Fixed an unreachable empty-state branch in `MessageBrowser`: the duplicated condition meant the "No messages found" copy never displayed; now distinguished from the pre-fetch prompt.

Closes #1

## Test plan

- [x] `go test ./...` (new `lastNStartSeq` table tests pass)
- [x] `go vet ./...`
- [x] `npx tsc --noEmit`
- [ ] Manual: open a stream with messages and click Fetch Messages — messages load
- [ ] Manual: open an empty stream and click Fetch Messages — see "No messages found"
- [ ] Manual: stream with 5 messages, ask for last 50 — returns the 5 (no underflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)