### PR TITLE
chore: fix pre-existing eslint failure on shadcn sidebar

### DIFF
--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -711,6 +711,7 @@ function SidebarMenuSubButton({
 }
 
 export {
+  // eslint-disable-next-line react-refresh/only-export-components
   useSidebar,
   Sidebar,
   SidebarContent,


### PR DESCRIPTION
## Summary

The `react-refresh/only-export-components` rule has been failing on `main` since the shadcn sidebar component was added — the file exports the `useSidebar` hook alongside `Sidebar*` components, which the rule disallows.

This is unrelated to any feature change but is currently blocking CI on every PR. Standard shadcn shape; splitting the hook into its own file would ripple through every Sidebar consumer for no real win, so I disabled the rule on the hook identifier only.

## Test plan

- [x] `pnpm lint` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)