### PR TITLE
fix: keep status badge clear of dialog close button on long consumer names (#2)

### DIFF
--- a/frontend/src/components/consumers/ConsumerDetail.tsx
+++ b/frontend/src/components/consumers/ConsumerDetail.tsx
@@ -110,14 +110,14 @@ export function ConsumerDetail({ consumer, onClose, onRefresh, getActivityStatus
     <Dialog open onOpenChange={() => onClose()}>
       <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 min-w-0">
+          <DialogTitle className="flex items-center gap-2 min-w-0 pr-6">
             <Users className="h-5 w-5 shrink-0" />
-            <span className="truncate" title={consumer.name}>Consumer: {consumer.name}</span>
             {consumer.paused ? (
               <Badge className="bg-yellow-500 text-white shrink-0">Paused</Badge>
             ) : (
               <Badge className="bg-green-500 text-white shrink-0">Active</Badge>
             )}
+            <span className="truncate" title={consumer.name}>Consumer: {consumer.name}</span>
           </DialogTitle>
           <DialogDescription>
             Detailed information and statistics for this consumer


### PR DESCRIPTION
## Summary

Follow-up to #4 based on @micah686's feedback in #2: with a long consumer name, the trailing `Active`/`Paused` badge is pushed to the right edge of the title row and ends up 8px to the left of the dialog's `X` close button — same vertical band, mismatched right edges. Aligning them with a negative margin isn't viable because the close `X` shares that y-range and would overlap the badge text.

This moves the status badge to the **leading** position in the title (right after the Users icon) so the truncated consumer name owns the right end of the row and nothing competes with the close button. Also adds `pr-6` to the title row so the truncate ellipsis stays comfortably clear of the `X`.

Layout before: `[icon] Consumer: {long-name}… [Active]`
Layout after: `[icon] [Active] Consumer: {long-name}…`

Closes the residual visual issue raised on #2.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `eslint` clean on the changed file
- [ ] Manual: long consumer name — badge sits cleanly between icon and name; truncate ellipsis is right-aligned without crowding the close `X`
- [ ] Manual: short consumer name — badge still next to icon, name fully visible
- [ ] Manual: paused consumer — Paused badge renders in the same leading position

🤖 Generated with [Claude Code](https://claude.com/claude-code)