### PR TITLE
fix: prevent dialog overflow for non-breakable consumer names (#2)

### DIFF
--- a/frontend/src/components/consumers/ConsumerDetail.tsx
+++ b/frontend/src/components/consumers/ConsumerDetail.tsx
@@ -108,8 +108,8 @@ export function ConsumerDetail({ consumer, onClose, onRefresh, getActivityStatus
 
   return (
     <Dialog open onOpenChange={() => onClose()}>
-      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-x-hidden overflow-y-auto">
+        <DialogHeader className="min-w-0">
           <DialogTitle className="flex items-center gap-2 min-w-0 pr-6">
             <Users className="h-5 w-5 shrink-0" />
             {consumer.paused ? (
@@ -117,7 +117,7 @@ export function ConsumerDetail({ consumer, onClose, onRefresh, getActivityStatus
             ) : (
               <Badge className="bg-green-500 text-white shrink-0">Active</Badge>
             )}
-            <span className="truncate" title={consumer.name}>Consumer: {consumer.name}</span>
+            <span className="min-w-0 flex-1 truncate" title={consumer.name}>Consumer: {consumer.name}</span>
           </DialogTitle>
           <DialogDescription>
             Detailed information and statistics for this consumer


### PR DESCRIPTION
## Summary

Follow-up #2 to @micah686's reports on #2. With his latest screenshot we can finally see the *real* root cause: when a consumer name is a single non-breakable string (e.g. `1234567890-qwertyuiop-09876543210-poiuytrewq`), the previous `truncate` simply doesn't fire and the entire dialog overflows horizontally — which is why the close `X` ends up rendered far past the viewport.

### Why the previous fix didn't survive

The title span has `white-space: nowrap`, so its `min-content` is the **full text width**. CSS Grid items default to `min-width: auto` (= min-content), and that propagates upwards:

```
span (min-content = full text)
  └── DialogTitle  (had min-w-0 → didn't help, see below)
        └── DialogHeader  (grid item with default min-width:auto = min-content)
              └── DialogContent  (grid track grows past max-w-2xl)
```

`min-w-0` on the `DialogTitle` lets the title itself shrink, but the propagated `min-content` from the span still goes up through `DialogHeader`, and `DialogHeader` (a grid item) has `min-width: auto`, so it forces the track wider than `max-w-2xl`. The dialog grows, the page gets a horizontal scrollbar, and the absolute-positioned close `X` renders off-screen.

### Fix

Three coordinated changes:

- `DialogHeader`: add `min-w-0` so the grid item can shrink below its intrinsic min-content
- Title span: add `min-w-0 flex-1` alongside `truncate` so the flex item is explicitly allowed to shrink and fill the remaining row space
- `DialogContent`: add `overflow-x-hidden` as a belt-and-braces guard against any residual horizontal growth (the inner `<pre overflow-x-auto>` for JSON message data is unaffected)

Closes the residual cutoff/close-button mis-position reported on #2.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `eslint` clean on the changed file
- [ ] Manual: consumer with a 60+ char hyphen-only name — dialog stays at `max-w-2xl`, name truncates with ellipsis, hover shows full name, X close button is at the dialog's top-right
- [ ] Manual: short name — visual unchanged
- [ ] Manual: pulled-messages section with a JSON payload — inner horizontal scroll on the `<pre>` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)