### PR TITLE
feat: move MessageBrowser and ConsumerDetail to right-side Sheet

### DIFF
--- a/frontend/src/components/consumers/ConsumerDetail.tsx
+++ b/frontend/src/components/consumers/ConsumerDetail.tsx
@@ -6,7 +6,7 @@ import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '../ui/sheet';
 import { toast } from 'sonner';
 import { pauseConsumer, resumeConsumer } from '../../services/api-client';
 import { fetchNextMessages, type PulledMessage } from '../../services/api-client-extended';
@@ -107,10 +107,13 @@ export function ConsumerDetail({ consumer, onClose, onRefresh, getActivityStatus
   const lagLabel = getLagLabel(consumer.pending);
 
   return (
-    <Dialog open onOpenChange={() => onClose()}>
-      <DialogContent className="max-w-2xl max-h-[85vh] overflow-x-hidden overflow-y-auto">
-        <DialogHeader className="min-w-0">
-          <DialogTitle className="flex items-center gap-2 min-w-0 pr-6">
+    <Sheet open onOpenChange={() => onClose()}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 overflow-x-hidden p-0 sm:w-1/2 sm:max-w-none"
+      >
+        <SheetHeader className="border-b">
+          <SheetTitle className="flex min-w-0 items-center gap-2 pr-6">
             <Users className="h-5 w-5 shrink-0" />
             {consumer.paused ? (
               <Badge className="bg-yellow-500 text-white shrink-0">Paused</Badge>
@@ -118,13 +121,13 @@ export function ConsumerDetail({ consumer, onClose, onRefresh, getActivityStatus
               <Badge className="bg-green-500 text-white shrink-0">Active</Badge>
             )}
             <span className="min-w-0 flex-1 truncate" title={consumer.name}>Consumer: {consumer.name}</span>
-          </DialogTitle>
-          <DialogDescription>
+          </SheetTitle>
+          <SheetDescription>
             Detailed information and statistics for this consumer
-          </DialogDescription>
-        </DialogHeader>
+          </SheetDescription>
+        </SheetHeader>
 
-        <div className="space-y-6">
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-4">
           <MetricsGrid consumer={consumer} />
           <LagIndicator lagColor={lagColor} lagLabel={lagLabel} pending={consumer.pending} />
           <ConfigAndTimestamps consumer={consumer} activity={activity} />
@@ -137,24 +140,24 @@ export function ConsumerDetail({ consumer, onClose, onRefresh, getActivityStatus
             pulling={pulling}
             messages={pulledMessages}
           />
-
-          {/* Actions */}
-          <div className="flex items-center gap-3 pt-4 border-t">
-            {consumer.paused ? (
-              <Button onClick={handleResume} disabled={loading} size="sm">
-                <Play className="mr-2 h-4 w-4" />
-                Resume Consumer
-              </Button>
-            ) : (
-              <Button onClick={handlePause} disabled={loading} variant="secondary" size="sm">
-                <Pause className="mr-2 h-4 w-4" />
-                Pause Consumer
-              </Button>
-            )}
-          </div>
         </div>
-      </DialogContent>
-    </Dialog>
+
+        {/* Actions */}
+        <div className="flex items-center gap-3 border-t p-4">
+          {consumer.paused ? (
+            <Button onClick={handleResume} disabled={loading} size="sm">
+              <Play className="mr-2 h-4 w-4" />
+              Resume Consumer
+            </Button>
+          ) : (
+            <Button onClick={handlePause} disabled={loading} variant="secondary" size="sm">
+              <Pause className="mr-2 h-4 w-4" />
+              Pause Consumer
+            </Button>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 }
 

--- a/frontend/src/components/streams/MessageBrowser.tsx
+++ b/frontend/src/components/streams/MessageBrowser.tsx
@@ -6,8 +6,8 @@ import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import {
-  Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle,
-} from '../ui/dialog';
+  Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle,
+} from '../ui/sheet';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { JsonViewer } from '../ui/json-viewer';
@@ -69,19 +69,23 @@ export function MessageBrowser({ streamName, onClose }: MessageBrowserProps) {
   if (!streamName) return null;
 
   return (
-    <Dialog open={!!streamName} onOpenChange={() => onClose()}>
-      <DialogContent className="max-w-5xl max-h-[85vh]">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Eye className="h-5 w-5" /> Browse Messages: {streamName}
-          </DialogTitle>
-          <DialogDescription>
+    <Sheet open={!!streamName} onOpenChange={() => onClose()}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 p-0 sm:w-1/2 sm:max-w-none"
+      >
+        <SheetHeader className="border-b">
+          <SheetTitle className="flex min-w-0 items-center gap-2 pr-6">
+            <Eye className="h-5 w-5 shrink-0" />
+            <span className="truncate" title={streamName}>Browse Messages: {streamName}</span>
+          </SheetTitle>
+          <SheetDescription>
             Replay and browse messages stored in this stream
-          </DialogDescription>
-        </DialogHeader>
+          </SheetDescription>
+        </SheetHeader>
 
         {/* Filter controls */}
-        <div className="space-y-3 border rounded-lg p-4">
+        <div className="space-y-3 border-b p-4">
           <div className="flex items-end gap-4 flex-wrap">
             <Tabs value={filterMode} onValueChange={(v) => setFilterMode(v as FilterMode)} className="flex-1">
               <TabsList className="grid w-full grid-cols-4">
@@ -145,7 +149,7 @@ export function MessageBrowser({ streamName, onClose }: MessageBrowserProps) {
         </div>
 
         {/* Messages list */}
-        <div className="overflow-auto max-h-[50vh]">
+        <div className="min-h-0 flex-1 overflow-auto">
           {loading ? (
             <div className="flex items-center justify-center py-12">
               <div className="animate-spin h-6 w-6 border-2 border-primary border-t-transparent rounded-full" />
@@ -177,9 +181,9 @@ export function MessageBrowser({ streamName, onClose }: MessageBrowserProps) {
                         onClick={() => toggleExpand(msg.sequence)}
                       >
                         {expandedSeqs.has(msg.sequence) ? (
-                          <JsonViewer data={msg.data} defaultExpanded className="max-w-lg" />
+                          <JsonViewer data={msg.data} defaultExpanded />
                         ) : (
-                          <pre className="text-xs max-w-md truncate font-mono bg-muted p-1 rounded">
+                          <pre className="text-xs truncate font-mono bg-muted p-1 rounded">
                             {typeof msg.data === 'string' ? msg.data : JSON.stringify(msg.data)}
                           </pre>
                         )}
@@ -194,7 +198,7 @@ export function MessageBrowser({ streamName, onClose }: MessageBrowserProps) {
             </Table>
           )}
         </div>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 }


### PR DESCRIPTION
## Summary

The centered modal we were using for both the stream message browser and the consumer detail was awkward to use — `max-h-[85vh]` minus the header, description and filter controls left only a small inner scroll area for the actual content. Switched both to a right-side **Sheet** with 50% viewport width on desktop (full width on mobile) so they feel like inspectors that you skim alongside the list, not popups that block it.

### Why Sheet here

- Full viewport height — the messages table and consumer details get the entire visible area, with a sticky header (and a sticky action bar for ConsumerDetail) instead of a single tightly capped scroll region
- Stream/consumer list behind stays visible, preserving context for the natural "select → inspect → close → next" flow
- Same Radix dialog primitive underneath, so Esc / click-outside / focus trap behavior is identical to before

### Layout details

- `SheetContent` overrides the default `sm:max-w-sm` (which made the sheet too narrow) to `sm:w-1/2 sm:max-w-none`, with `w-full` for mobile
- Custom flex layout (`flex flex-col gap-0 p-0`) so the sheet is split into:
  - **Sticky header** with title / description and close X
  - **Scrollable body** (`min-h-0 flex-1 overflow-auto`) — the long content scrolls inside the sheet, not the page
  - **Sticky action bar** (ConsumerDetail only) — Pause/Resume buttons stay accessible without scrolling back up
- Removed the `max-w-md` / `max-w-lg` width caps on the message Data cell since with 50% viewport we no longer need them
- Inner `<pre>` for collapsed JSON keeps `truncate`; expanded JsonViewer is no longer constrained to `max-w-lg`

## Test plan

- [x] `npx tsc --noEmit`
- [x] `eslint` clean on both changed files
- [x] `pnpm build` succeeds (production bundle)
- [ ] Manual: open a stream → click eye → sheet slides in from the right at 50% width; filters render; Fetch Messages populates the list and the table fills the remaining height
- [ ] Manual: long subjects in a message — table cells render without forcing horizontal scroll
- [ ] Manual: open a consumer → details visible with metrics, lag, config, timestamps, pull-messages section; Pause/Resume button stays pinned at the bottom; Esc closes
- [ ] Manual: mobile (< 640px) — sheet takes full viewport width
- [ ] Manual: long consumer name — truncates with ellipsis, X button stays at top-right of the sheet (validates the v0.3.9 truncation fix still holds in the new layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)